### PR TITLE
feat: add homepage link to header

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -157,13 +157,13 @@ function Header(){
   return (
     <header className="sticky top-0 z-30 backdrop-blur bg-[rgba(248,247,244,0.7)] border-b">
       <div className="max-w-6xl mx-auto px-4 md:px-6 flex items-center justify-between h-16">
-        <div className="flex items-center gap-2">
+        <Link to="/" className="flex items-center gap-2">
           <div className="h-9 w-9 rounded-xl brand-gradient grid place-items-center text-white shadow"><Compass className="w-5 h-5" /></div>
           <div className="leading-tight">
             <div className="font-semibold tracking-tight">Offgrid Overland</div>
             <div className="text-xs text-neutral-500">Passeios familiares em ritmo tranquilo</div>
           </div>
-        </div>
+        </Link>
         <nav className="hidden md:flex items-center gap-6 text-sm">
           <a href="#proximos" className="hover:underline">Passeios</a>
           <a href="#galeria" className="hover:underline">Galeria</a>


### PR DESCRIPTION
## Summary
- make site logo and tagline link to homepage for quick navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e38f34158832aa54839450ee3fd5d