### PR TITLE
Add dedicated trip pages with gallery and pricing

### DIFF
--- a/netlify/functions/trips.mjs
+++ b/netlify/functions/trips.mjs
@@ -52,9 +52,19 @@ export async function handler(event) {
   try {
     if (!supabaseUrl || !serviceKey) return json(500, { error: 'Missing SUPABASE env vars' }, event)
 
-    // Público: listar passeios
+    // Público: listar ou obter passeio específico
     if (event.httpMethod === 'GET') {
       const params = event.queryStringParameters || {}
+      const id = params.id
+      if (id) {
+        const { data, error } = await supabase
+          .from('trips')
+          .select('*')
+          .eq('id', id)
+          .single()
+        if (error) return json(404, { error: error.message }, event)
+        return json(200, data, event)
+      }
       const all = params.all === '1' || params.all === 'true'
       const upcoming = params.upcoming === '1' || params.upcoming === 'true'
       let q = supabase.from('trips').select('*')
@@ -77,6 +87,8 @@ export async function handler(event) {
         location: body.location || null,
         description: body.description || null,
         images: body.images || [],
+        price_car: body.priceCar ?? body.price_car ?? null,
+        price_extra: body.priceExtra ?? body.price_extra ?? null,
       }
       if (!payload.name || !payload.date_time) return json(400, { error: 'name and date_time are required' }, event)
       const { data, error } = await supabase.from('trips').insert(payload).select().single()
@@ -93,6 +105,8 @@ export async function handler(event) {
         location: body.location,
         description: body.description,
         images: body.images || [],
+        price_car: body.priceCar ?? body.price_car,
+        price_extra: body.priceExtra ?? body.price_extra,
       }
       const { data, error } = await supabase.from('trips').update(patch).eq('id', body.id).select().single()
       if (error) return json(500, { error: error.message }, event)

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Routes, Route, Link } from "react-router-dom";
+import { Routes, Route, Link, useParams } from "react-router-dom";
 import { motion } from "framer-motion";
 import { Compass, Mountain, Tent, Truck, MapPin, CalendarClock, Camera as ImageIcon } from "lucide-react";
 import AdminPage from "./pages/Admin.jsx";
@@ -38,6 +38,7 @@ export default function App() {
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/admin" element={<AdminPage />} />
+          <Route path="/passeio/:id" element={<TripPage />} />
         </Routes>
       </main>
       <Footer />
@@ -74,11 +75,7 @@ function Home() {
         ) : (
           <div className="grid md:grid-cols-2 gap-6">
             {upcoming.map(trip => (
-              <TripCard key={trip.id} trip={trip} onSubmit={async (payload) => {
-                const res = await fetch(API.register, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ ...payload, tripId: trip.id }) });
-                if (res.ok) alert("Inscrição recebida! Entraremos em contato.");
-                else alert("Não foi possível enviar sua inscrição. Tente novamente.");
-              }} />
+              <TripCard key={trip.id} trip={trip} />
             ))}
           </div>
         )}
@@ -121,29 +118,95 @@ function Home() {
   );
 }
 
-function TripCard({ trip, onSubmit }) {
-  const [name, setName] = useState(""); const [whatsapp, setWhatsapp] = useState(""); const [email, setEmail] = useState("");
+function TripCard({ trip }) {
   const date = new Date(trip.date_time);
   const formatted = new Intl.DateTimeFormat("pt-BR",{dateStyle:"full", timeStyle:"short"}).format(date);
   return (
-    <Card className="overflow-hidden border shadow-sm">
-      {trip.images?.[0] && <img src={trip.images[0]} alt={trip.name} className="w-full h-44 object-cover" />}
-      <CardContent className="p-4">
-        <h3 className="text-lg font-semibold tracking-tight">{trip.name}</h3>
-        <div className="flex items-center gap-2 text-sm text-neutral-600 mt-1"><CalendarClock className="w-4 h-4" /><span>{formatted}</span></div>
-        <div className="flex items-center gap-2 text-sm text-neutral-600 mt-1"><MapPin className="w-4 h-4" /><span>{trip.location}</span></div>
-        <p className="text-sm text-neutral-600 mt-3">{trip.description}</p>
-        <form className="grid md:grid-cols-3 gap-3 mt-4" onSubmit={(e)=>{e.preventDefault(); if(!name||!whatsapp||!email) return alert("Preencha todos os campos."); onSubmit({name,whatsapp,email}); setName(""); setWhatsapp(""); setEmail("");}}>
-          <div><Label htmlFor={`nome-${trip.id}`}>Nome</Label><Input id={`nome-${trip.id}`} value={name} onChange={e=>setName(e.target.value)} placeholder="Seu nome" /></div>
-          <div><Label htmlFor={`zap-${trip.id}`}>WhatsApp</Label><Input id={`zap-${trip.id}`} value={whatsapp} onChange={e=>setWhatsapp(e.target.value)} placeholder="(11) 98765-4321" /></div>
-          <div><Label htmlFor={`email-${trip.id}`}>E-mail</Label>
-            <div className="flex gap-2"><Input id={`email-${trip.id}`} type="email" value={email} onChange={e=>setEmail(e.target.value)} placeholder="voce@email.com" />
-              <Button type="submit">Inscrever</Button>
-            </div>
+    <Link to={`/passeio/${trip.id}`} className="block group">
+      <Card className="overflow-hidden border shadow-sm relative">
+        {trip.images?.[0] && <img src={trip.images[0]} alt={trip.name} className="w-full h-44 object-cover" />}
+        <CardContent className="p-4">
+          <h3 className="text-lg font-semibold tracking-tight">{trip.name}</h3>
+          <div className="flex items-center gap-2 text-sm text-neutral-600 mt-1"><CalendarClock className="w-4 h-4" /><span>{formatted}</span></div>
+          <div className="flex items-center gap-2 text-sm text-neutral-600 mt-1"><MapPin className="w-4 h-4" /><span>{trip.location}</span></div>
+          <p className="text-sm text-neutral-600 mt-3">{trip.description}</p>
+        </CardContent>
+        <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 group-hover:opacity-100 transition">
+          <span className="inline-flex items-center justify-center gap-1.5 rounded-2xl px-3 py-2 text-sm bg-[var(--moss)] text-white">Participe</span>
+        </div>
+      </Card>
+    </Link>
+  );
+}
+
+function TripPage() {
+  const { id } = useParams();
+  const [trip, setTrip] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [name, setName] = useState("");
+  const [whatsapp, setWhatsapp] = useState("");
+  const [email, setEmail] = useState("");
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+  const [lightboxIndex, setLightboxIndex] = useState(0);
+
+  useEffect(() => {
+    fetch(`${API.trips}?id=${id}`).then(r=>r.json()).then(d=>{ setTrip(d); setLoading(false); }).catch(()=>setLoading(false));
+  }, [id]);
+
+  if (loading) return <div className="py-10 text-center text-neutral-600">Carregando…</div>;
+  if (!trip) return <div className="py-10 text-center text-neutral-600">Passeio não encontrado.</div>;
+
+  const date = new Date(trip.date_time);
+  const formatted = new Intl.DateTimeFormat("pt-BR",{dateStyle:"full", timeStyle:"short"}).format(date);
+  const paragraphs = (trip.description || "").split(/\n+/).map((p,i)=>(<p key={i} className="mt-2">{p}</p>));
+
+  return (
+    <div className="py-8 max-w-3xl mx-auto">
+      {trip.images?.[0] && <img src={trip.images[0]} alt={trip.name} className="w-full h-64 object-cover rounded-3xl shadow-sm" />}
+      <h1 className="text-2xl font-semibold mt-4">{trip.name}</h1>
+      <div className="flex items-center gap-2 text-sm text-neutral-600 mt-1"><CalendarClock className="w-4 h-4" /><span>{formatted}</span></div>
+      <div className="flex items-center gap-2 text-sm text-neutral-600 mt-1"><MapPin className="w-4 h-4" /><span>{trip.location}</span></div>
+      <div className="mt-4 text-neutral-700">{paragraphs}</div>
+      <div className="mt-4 text-sm text-neutral-700 space-y-1">
+        {trip.price_car && <div>Preço por carro (2 pessoas): <span className="font-medium">{trip.price_car}</span></div>}
+        {trip.price_extra && <div>Preço por pessoa adicional: <span className="font-medium">{trip.price_extra}</span></div>}
+      </div>
+
+      {trip.images?.length>1 && (
+        <section className="mt-6">
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+            {trip.images.map((src,i)=>(
+              <button key={i} className="relative group" onClick={()=>{ setLightboxIndex(i); setLightboxOpen(true); }}>
+                <img src={src} alt="" className="w-full h-32 object-cover rounded-xl" />
+              </button>
+            ))}
           </div>
-        </form>
-      </CardContent>
-    </Card>
+          {lightboxOpen && (
+            <Lightbox
+              images={trip.images.map(s=>({src:s, alt:trip.name}))}
+              startIndex={lightboxIndex}
+              onClose={()=>setLightboxOpen(false)}
+            />
+          )}
+        </section>
+      )}
+
+      <form className="grid md:grid-cols-3 gap-3 mt-8" onSubmit={async (e)=>{
+        e.preventDefault();
+        if(!name||!whatsapp||!email) return alert("Preencha todos os campos.");
+        const res = await fetch(API.register, { method:"POST", headers:{"Content-Type":"application/json"}, body: JSON.stringify({ name, whatsapp, email, tripId: trip.id }) });
+        if(res.ok){ alert("Inscrição recebida! Entraremos em contato."); setName(""); setWhatsapp(""); setEmail(""); }
+        else alert("Não foi possível enviar sua inscrição. Tente novamente.");
+      }}>
+        <div><Label htmlFor="nome">Nome</Label><Input id="nome" value={name} onChange={e=>setName(e.target.value)} placeholder="Seu nome" /></div>
+        <div><Label htmlFor="zap">WhatsApp</Label><Input id="zap" value={whatsapp} onChange={e=>setWhatsapp(e.target.value)} placeholder="(11) 98765-4321" /></div>
+        <div><Label htmlFor="email">E-mail</Label>
+          <div className="flex gap-2"><Input id="email" type="email" value={email} onChange={e=>setEmail(e.target.value)} placeholder="voce@email.com" />
+            <Button type="submit">Inscrever</Button>
+          </div>
+        </div>
+      </form>
+    </div>
   );
 }
 

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -80,7 +80,7 @@ export default function AdminPage(){
       {/* dialogs */}
       {newTripOpen && <Dialog onClose={()=>setNewTripOpen(false)}>
         <h3 className="text-lg font-semibold mb-2">Novo passeio</h3>
-        <TripForm initial={{ id: crypto.randomUUID(), name:"", dateTime:new Date().toISOString(), location:"", description:"", images:[] }}
+        <TripForm initial={{ id: crypto.randomUUID(), name:"", dateTime:new Date().toISOString(), location:"", description:"", images:[], priceCar:"", priceExtra:"" }}
           onCancel={()=>setNewTripOpen(false)}
           onSave={async (created)=>{
             const res = await fetch(API.trips, { method:"POST", credentials:"include", headers:{ "Content-Type":"application/json" }, body: JSON.stringify(created) });
@@ -90,7 +90,7 @@ export default function AdminPage(){
 
       {editing && <Dialog onClose={()=>setEditing(null)}>
         <h3 className="text-lg font-semibold mb-2">Editar passeio</h3>
-        <TripForm initial={{ id:editing.id, name:editing.name, dateTime:editing.date_time, location:editing.location, description:editing.description, images:editing.images||[] }}
+        <TripForm initial={{ id:editing.id, name:editing.name, dateTime:editing.date_time, location:editing.location, description:editing.description, images:editing.images||[], priceCar:editing.price_car, priceExtra:editing.price_extra }}
           onCancel={()=>setEditing(null)}
           onSave={async (patch)=>{
             const res = await fetch(API.trips, { method:"PUT", credentials:"include", headers:{ "Content-Type":"application/json" }, body: JSON.stringify(patch) });
@@ -214,6 +214,10 @@ function TripForm({ initial, onSave, onCancel }){
         <div><Label>Local</Label><Input value={form.location} onChange={e=>update({location:e.target.value})} placeholder="Cidade / Região" /></div>
       </div>
       <div><Label>Descrição</Label><Textarea rows={4} value={form.description} onChange={e=>update({description:e.target.value})} placeholder="Resumo do roteiro, nível e recomendações." /></div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <div><Label>Preço por carro (2 pessoas)</Label><Input value={form.priceCar} onChange={e=>update({priceCar:e.target.value})} placeholder="R$ 0,00" /></div>
+        <div><Label>Preço por pessoa adicional</Label><Input value={form.priceExtra} onChange={e=>update({priceExtra:e.target.value})} placeholder="R$ 0,00" /></div>
+      </div>
       <div>
         <Label>Fotos (URLs)</Label>
         <div className="flex gap-2">


### PR DESCRIPTION
## Summary
- link upcoming trip cards to individual pages and show a “Participe” overlay on hover
- add dedicated trip page with description formatting, image gallery lightbox, pricing and registration form
- allow trips API and admin to manage per-car and extra-person pricing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689e3f1f8264832a9697c68e946badf3