### PR TITLE
Display full trip description on trip page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -158,7 +158,13 @@ function TripPage() {
 
   const date = new Date(trip.date_time);
   const formatted = new Intl.DateTimeFormat("pt-BR",{dateStyle:"full", timeStyle:"short"}).format(date);
-  const paragraphs = (trip.description || "").split(/\n+/).map((p,i)=>(<p key={i} className="mt-2">{p}</p>));
+  const paragraphs = (trip.complete_description || trip.description || "")
+    .split(/\n+/)
+    .map((p, i) => (
+      <p key={i} className="mt-2">
+        {p}
+      </p>
+    ));
 
 
   return (


### PR DESCRIPTION
## Summary
- Render a trip's `complete_description` field when viewing its dedicated page so visitors see full details.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f3498f174832abed169bd98475be1