### PR TITLE
Add trip difficulty level badges

### DIFF
--- a/netlify/functions/trips.mjs
+++ b/netlify/functions/trips.mjs
@@ -88,6 +88,7 @@ export async function handler(event) {
         description: body.description || null,
         complete_description: body.completeDescription || body.complete_description || null,
         images: body.images || [],
+        difficulty: body.difficulty || null,
         price_car: body.priceCar ?? body.price_car ?? null,
         price_extra: body.priceExtra ?? body.price_extra ?? null,
       }
@@ -107,6 +108,7 @@ export async function handler(event) {
         description: body.description,
         complete_description: body.completeDescription ?? body.complete_description,
         images: body.images || [],
+        difficulty: body.difficulty,
         price_car: body.priceCar ?? body.price_car,
         price_extra: body.priceExtra ?? body.price_extra,
       }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,6 +29,13 @@ function Label({ htmlFor, children }){ return <label htmlFor={htmlFor} className
 
 const isUpcoming = (iso) => new Date(iso).getTime() >= Date.now();
 
+const difficultyColors = {
+  "Nível 1 – SUV/Leve": "bg-blue-600 text-white",
+  "Nível 2 – 4x4 Médio": "bg-green-600 text-white",
+  "Nível 3 – 4x4 Pesado": "bg-yellow-400 text-black",
+  "Nível 4 – Off-road Extremo": "bg-black text-white",
+};
+
 export default function App() {
   return (
     <div className="min-h-screen bg-[var(--bg)] text-[var(--fg)]">
@@ -124,7 +131,14 @@ function TripCard({ trip }) {
   return (
     <Link to={`/passeio/${trip.id}`} className="block group">
       <Card className="overflow-hidden border shadow-sm relative">
-        {trip.images?.[0] && <img src={trip.images[0]} alt={trip.name} className="w-full h-44 object-cover" />}
+        {trip.images?.[0] && (
+          <div className="relative">
+            <img src={trip.images[0]} alt={trip.name} className="w-full h-44 object-cover" />
+            {trip.difficulty && (
+              <span className={`absolute bottom-2 right-2 px-2 py-0.5 rounded text-[10px] font-medium ${difficultyColors[trip.difficulty] || 'bg-neutral-500 text-white'}`}>{trip.difficulty}</span>
+            )}
+          </div>
+        )}
         <CardContent className="p-4">
           <h3 className="text-lg font-semibold tracking-tight">{trip.name}</h3>
           <div className="flex items-center gap-2 text-sm text-neutral-600 mt-1"><CalendarClock className="w-4 h-4" /><span>{formatted}</span></div>

--- a/src/pages/Admin.jsx
+++ b/src/pages/Admin.jsx
@@ -80,7 +80,7 @@ export default function AdminPage(){
       {/* dialogs */}
       {newTripOpen && <Dialog onClose={()=>setNewTripOpen(false)}>
         <h3 className="text-lg font-semibold mb-2">Novo passeio</h3>
-        <TripForm initial={{ id: crypto.randomUUID(), name:"", dateTime:new Date().toISOString(), location:"", description:"", completeDescription:"", images:[], priceCar:"", priceExtra:"" }}
+        <TripForm initial={{ id: crypto.randomUUID(), name:"", dateTime:new Date().toISOString(), location:"", difficulty:"", description:"", completeDescription:"", images:[], priceCar:"", priceExtra:"" }}
 
           onCancel={()=>setNewTripOpen(false)}
           onSave={async (created)=>{
@@ -92,7 +92,7 @@ export default function AdminPage(){
       {editing && <Dialog onClose={()=>setEditing(null)}>
         <h3 className="text-lg font-semibold mb-2">Editar passeio</h3>
 
-        <TripForm initial={{ id:editing.id, name:editing.name, dateTime:editing.date_time, location:editing.location, description:editing.description, completeDescription:editing.complete_description, images:editing.images||[], priceCar:editing.price_car, priceExtra:editing.price_extra }}
+        <TripForm initial={{ id:editing.id, name:editing.name, dateTime:editing.date_time, location:editing.location, difficulty:editing.difficulty, description:editing.description, completeDescription:editing.complete_description, images:editing.images||[], priceCar:editing.price_car, priceExtra:editing.price_extra }}
           onCancel={()=>setEditing(null)}
           onSave={async (patch)=>{
             const res = await fetch(API.trips, { method:"PUT", credentials:"include", headers:{ "Content-Type":"application/json" }, body: JSON.stringify(patch) });
@@ -213,11 +213,21 @@ function TripForm({ initial, onSave, onCancel }){
   return (
     <form className="grid gap-3" onSubmit={(e)=>{ e.preventDefault(); if(!form.name) return alert("Defina um nome."); if(!form.dateTime) return alert("Defina data e hora."); onSave(form); }}>
       <div><Label>Nome do passeio</Label><Input value={form.name} onChange={e=>update({name:e.target.value})} placeholder="Ex.: Estrada-Parque Serra da Canastra" /></div>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <div><Label>Data e hora</Label><Input type="datetime-local" value={toLocalInputValue(form.dateTime)} onChange={e=>update({dateTime: new Date(e.target.value).toISOString()})} /></div>
-        <div><Label>Local</Label><Input value={form.location} onChange={e=>update({location:e.target.value})} placeholder="Cidade / Região" /></div>
-      </div>
-      <div><Label>Descrição</Label><Textarea rows={4} value={form.description} onChange={e=>update({description:e.target.value})} placeholder="Resumo do roteiro, nível e recomendações." /></div>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div><Label>Data e hora</Label><Input type="datetime-local" value={toLocalInputValue(form.dateTime)} onChange={e=>update({dateTime: new Date(e.target.value).toISOString()})} /></div>
+          <div><Label>Local</Label><Input value={form.location} onChange={e=>update({location:e.target.value})} placeholder="Cidade / Região" /></div>
+        </div>
+        <div>
+          <Label>Dificuldade</Label>
+          <select value={form.difficulty} onChange={e=>update({difficulty:e.target.value})} className="w-full rounded-xl border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[var(--moss)] border-neutral-300">
+            <option value="">Selecione</option>
+            <option value="Nível 1 – SUV/Leve">Nível 1 – SUV/Leve</option>
+            <option value="Nível 2 – 4x4 Médio">Nível 2 – 4x4 Médio</option>
+            <option value="Nível 3 – 4x4 Pesado">Nível 3 – 4x4 Pesado</option>
+            <option value="Nível 4 – Off-road Extremo">Nível 4 – Off-road Extremo</option>
+          </select>
+        </div>
+        <div><Label>Descrição</Label><Textarea rows={4} value={form.description} onChange={e=>update({description:e.target.value})} placeholder="Resumo do roteiro, nível e recomendações." /></div>
       <div><Label>Descrição completa</Label><Textarea rows={8} value={form.completeDescription} onChange={e=>update({completeDescription:e.target.value})} placeholder="Detalhes completos do passeio." /></div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         <div><Label>Preço por carro (2 pessoas)</Label><Input value={form.priceCar} onChange={e=>update({priceCar:e.target.value})} placeholder="R$ 0,00" /></div>


### PR DESCRIPTION
## Summary
- add `difficulty` support to trips API
- allow admins to set difficulty for each trip
- show colored difficulty badge on trip cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f5d968b34832abaa163b1228bb81a