### PR TITLE
Add vehicle level guidance to home page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -74,6 +74,7 @@ function Home() {
     <>
       <Hero />
       <ValueProps />
+      <VehicleLevels />
 
       <section id="proximos" className="mt-12 md:mt-16">
         <SectionTitle icon={<CalendarClock className="w-5 h-5" />} title="Próximos passeios" subtitle="Inscreva-se para viver o overland em ritmo tranquilo." />
@@ -321,6 +322,102 @@ function ValueProps() {
         </Card>
       ))}
     </div>
+  );
+}
+
+function VehicleLevels() {
+  const levels = [
+    {
+      title: "Categoria 1 – Off-road Leve / SUV Urbano",
+      profile:
+        "Veículos com tração 4x4 ou AWD, mas projetados para conforto e uso predominantemente urbano, com alguma aptidão em estradas de terra e pisos irregulares. Limitados em ângulos de ataque/saída e altura livre do solo.",
+      requirements: [
+        "Tração AWD ou 4x4 sob demanda (muitas vezes sem reduzida real).",
+        "Altura livre do solo entre 18–22 cm.",
+        "Pneus de uso misto ou mais voltados para asfalto.",
+        "Suspensão confortável, mas não reforçada para impactos severos.",
+        "Sem proteções robustas de fábrica (skid plates, para-choques off-road).",
+        "Sistema eletrônico de tração (controle de descida, terrain select), mas sem bloqueios mecânicos.",
+      ],
+      examples:
+        "Jeep Renegade Trailhawk 2.0 turbo diesel 4x4 2019; Commander Overland 2.0 turbo diesel 4x4 2022",
+    },
+    {
+      title: "Categoria 2 – Off-road Moderado / Picapes e SUVs Médios",
+      profile:
+        "Veículos que equilibram uso rodoviário e off-road, aptos para trilhas médias, areia, lama leve e travessias rasas. Já contam com reduzida, estrutura mais robusta e altura livre superior.",
+      requirements: [
+        "Tração 4x4 com caixa de redução.",
+        "Altura livre do solo 22–24 cm.",
+        "Chassi mais robusto (monobloco reforçado ou chassi sobre longarinas).",
+        "Pneus AT de fábrica ou facilmente adaptáveis.",
+        "Ângulos de ataque/saída medianos.",
+        "Recursos como controle de descida e modos de terreno.",
+        "Sem bloqueios diferenciais mecânicos (ou apenas traseiro eletrônico opcional).",
+      ],
+      examples:
+        "Ram Rampage Rebel 2.0 turbo diesel 4x4 2022; Nissan Frontier XE 2.4 turbo 2022; Pajero TR4 2.0 gasolina 4x4 2012",
+    },
+    {
+      title: "Categoria 3 – Off-road Avançado / Expedição Pesada",
+      profile:
+        "Veículos preparados de fábrica ou facilmente adaptáveis para trilhas pesadas e expedições, com boa articulação de suspensão, altura livre elevada, bloqueios diferenciais opcionais e grande robustez mecânica.",
+      requirements: [
+        "Tração 4x4 com reduzida e bloqueio de diferencial (pelo menos traseiro).",
+        "Altura livre do solo 24–27 cm.",
+        "Chassi sobre longarinas ou monobloco extremamente reforçado.",
+        "Ângulos de ataque/saída favoráveis.",
+        "Capacidade de carga alta e tolerância a modificações (lift, pneus MT).",
+        "Mecânica confiável para uso extremo.",
+      ],
+      examples:
+        "Pajero Dakar 3.2 HPE turbo diesel 2018; Ranger XLT 3.0 V6 diesel 4x4 2024; Ram 1500 Rebel V8 gasolina 2020; Ram 2500 6.7 turbo diesel 4x4 2020",
+    },
+    {
+      title: "Categoria 4 – Off-road Extremo / Trial e Rock Crawling",
+      profile:
+        "Veículos com projeto ou preparo para enfrentar obstáculos severos, como pedras, lama profunda e subidas radicais, com máxima articulação e tração. São os mais indicados para aventuras pesadas e terrenos hostis.",
+      requirements: [
+        "Tração 4x4 com reduzida e bloqueio de diferencial dianteiro e traseiro.",
+        "Altura livre do solo acima de 27 cm.",
+        "Ângulos de ataque/saída máximos.",
+        "Grande curso de suspensão e possibilidade de modificações severas.",
+        "Construção extremamente robusta (eixo rígido na dianteira/traseira é comum).",
+        "Pode ter snorkel, guincho, proteções integrais e pneus MT de fábrica ou instalados.",
+      ],
+      examples:
+        "Suzuki Jimny 1.5 Sierra 4x4 2022; Troller T4 3.2 diesel 4x4 2018; Jeep Wrangler 3.6 gasolina 4x4 2016",
+    },
+  ];
+
+  return (
+    <section id="niveis" className="mt-16">
+      <SectionTitle
+        icon={<Truck className="w-5 h-5" />}
+        title="Níveis de passeio e veículos"
+        subtitle="Recomendações de acordo com o preparo do seu 4x4"
+      />
+      <div className="grid md:grid-cols-2 gap-6">
+        {levels.map((level) => (
+          <Card key={level.title} className="border shadow-sm">
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base">{level.title}</CardTitle>
+              <p className="mt-1 text-sm text-neutral-600">{level.profile}</p>
+            </CardHeader>
+            <CardContent className="text-sm text-neutral-700">
+              <ul className="list-disc pl-4 space-y-1">
+                {level.requirements.map((r, i) => (
+                  <li key={i}>{r}</li>
+                ))}
+              </ul>
+              <p className="mt-3 text-neutral-500">
+                Exemplos: {level.examples}
+              </p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary
- add VehicleLevels section describing recommended vehicles for each difficulty
- render VehicleLevels on home page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f6242859c832aa85dcd47b4ac3040